### PR TITLE
Add Chat module for reading publication subscriber chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This library provides Python interfaces for interacting with Substack's unoffici
 - Get user profile information and subscriptions
 - Fetch post content and metadata
 - Search for posts within newsletters
+- Access publication subscriber chats and threads
 - Access paywalled content **that you have written or paid for** with user-provided authentication
 
 ## Installation
@@ -18,38 +19,11 @@ This library provides Python interfaces for interacting with Substack's unoffici
 # Using pip
 pip install substack-api
 
-# Using uv
-uv add substack-api
+# Using poetry
+poetry add substack-api
 ```
 
-## Command-Line Interface
-
-The library includes a CLI for quick access from the terminal. All commands output JSON by default.
-
-```bash
-# Get the 5 newest posts from a newsletter
-substack newsletter posts https://example.substack.com --limit 5
-
-# Search for posts
-substack newsletter search https://example.substack.com "machine learning"
-
-# Get metadata for a specific post
-substack post metadata https://example.substack.com/p/my-post --pretty
-
-# Look up a user's subscriptions
-substack user subscriptions username
-
-# Browse categories
-substack categories
-substack category newsletters --name Technology
-
-# Run the quickstart guide for a full command reference
-substack quickstart
-```
-
-Use `--pretty` for human-readable output and `--cookies <path>` for authenticated access to paywalled content.
-
-## Python Usage Examples
+## Usage Examples
 
 ### Working with Newsletters
 
@@ -196,6 +170,32 @@ new_handle = resolve_handle_redirect("oldhandle")
 if new_handle:
     print(f"Handle was renamed to: {new_handle}")
 ```
+
+### Working with Chats
+
+Access publication subscriber chats (requires authentication):
+
+```python
+from substack_api import Chat, SubstackAuth
+
+# Set up authentication (required for chat access)
+auth = SubstackAuth(cookies_path="cookies.json")
+
+# Access a publication's chat using its publication ID
+chat = Chat(4906951, auth=auth)
+
+# Get recent threads
+threads = chat.get_threads(limit=5)
+for thread in threads:
+    print(f"Thread: {thread.body[:80]}...")
+    print(f"  By: {thread.author['name']} on {thread.created_at}")
+    print(f"  {thread.comment_count} messages")
+
+    # Get messages in thread
+    for msg in thread.get_messages():
+        print(f"    [{msg.created_at}] {msg.author['name']}: {msg.body[:60]}...")
+```
+
 ## Limitations
 
 - This is an unofficial library and not endorsed by Substack

--- a/README.md
+++ b/README.md
@@ -19,11 +19,38 @@ This library provides Python interfaces for interacting with Substack's unoffici
 # Using pip
 pip install substack-api
 
-# Using poetry
-poetry add substack-api
+# Using uv
+uv add substack-api
 ```
 
-## Usage Examples
+## Command-Line Interface
+
+The library includes a CLI for quick access from the terminal. All commands output JSON by default.
+
+```bash
+# Get the 5 newest posts from a newsletter
+substack newsletter posts https://example.substack.com --limit 5
+
+# Search for posts
+substack newsletter search https://example.substack.com "machine learning"
+
+# Get metadata for a specific post
+substack post metadata https://example.substack.com/p/my-post --pretty
+
+# Look up a user's subscriptions
+substack user subscriptions username
+
+# Browse categories
+substack categories
+substack category newsletters --name Technology
+
+# Run the quickstart guide for a full command reference
+substack quickstart
+```
+
+Use `--pretty` for human-readable output and `--cookies <path>` for authenticated access to paywalled content.
+
+## Python Usage Examples
 
 ### Working with Newsletters
 

--- a/docs/api-reference/chat.md
+++ b/docs/api-reference/chat.md
@@ -1,0 +1,313 @@
+# Chat
+
+The chat module provides access to Substack publication subscriber chats, including threads and messages.
+
+## Classes
+
+- [`Chat`](#chat-class) - Publication chat room
+- [`ChatThread`](#chatthread) - Thread within a chat
+- [`ChatMessage`](#chatmessage) - Message/reply in a thread
+
+## Exceptions
+
+- [`ChatError`](#chaterror) - Base exception for chat-related errors
+- [`ChatAuthenticationRequired`](#chatauthenticationrequired) - Authentication is required
+- [`ChatAccessDenied`](#chataccessdenied) - Access is denied
+- [`ChatNotFound`](#chatnotfound) - Chat/publication not found
+- [`ThreadNotFound`](#threadnotfound) - Thread not found
+
+---
+
+## Chat Class
+
+The `Chat` class represents a publication's community chat and provides access to threads.
+
+### Class Definition
+
+```python
+Chat(publication_id: Union[str, int], auth: SubstackAuth)
+```
+
+### Parameters
+
+- `publication_id` (Union[str, int]): The publication ID to access the chat for
+- `auth` (SubstackAuth): Authentication handler for API requests
+
+### Properties
+
+#### `publication_id -> int`
+
+The publication ID for this chat.
+
+### Methods
+
+#### `get_threads(limit: Optional[int] = None, force_refresh: bool = False) -> List[ChatThread]`
+
+Get threads from the publication chat.
+
+##### Parameters
+
+- `limit` (Optional[int]): Maximum number of threads to return. If None, returns all.
+- `force_refresh` (bool): If True, fetch fresh data from the API.
+
+##### Returns
+
+- `List[ChatThread]`: List of ChatThread objects.
+
+##### Raises
+
+- `ChatAuthenticationRequired`: If authentication is required.
+- `ChatNotFound`: If the publication is not found.
+- `ChatAccessDenied`: If access to the chat is denied.
+
+#### `get_thread(thread_id: str) -> ChatThread`
+
+Get a specific thread by its ID.
+
+##### Parameters
+
+- `thread_id` (str): The UUID of the thread to retrieve.
+
+##### Returns
+
+- `ChatThread`: The ChatThread object for the specified thread.
+
+---
+
+## ChatThread
+
+The `ChatThread` class represents a thread within a publication chat.
+
+### Class Definition
+
+```python
+ChatThread(publication_id: Union[str, int], thread_id: str, auth: SubstackAuth, _data: Optional[Dict] = None)
+```
+
+### Parameters
+
+- `publication_id` (Union[str, int]): The publication ID this thread belongs to.
+- `thread_id` (str): The unique identifier (UUID) for this thread.
+- `auth` (SubstackAuth): Authentication handler for API requests.
+- `_data` (Optional[Dict]): Pre-fetched thread data (for internal use).
+
+### Properties
+
+#### `id -> str`
+
+The unique identifier (UUID) for this thread.
+
+#### `body -> str`
+
+The text content of the thread's original post.
+
+#### `author -> Dict[str, Any]`
+
+The author information dictionary. Contains keys like 'id', 'name', 'handle', 'photo_url'.
+
+#### `created_at -> str`
+
+The ISO timestamp when the thread was created.
+
+#### `comment_count -> int`
+
+The number of replies/comments in this thread.
+
+#### `raw_data -> Optional[Dict[str, Any]]`
+
+The raw thread data dictionary from the API.
+
+### Methods
+
+#### `get_messages(limit: Optional[int] = None, force_refresh: bool = False) -> List[ChatMessage]`
+
+Get all messages/replies in this thread.
+
+##### Parameters
+
+- `limit` (Optional[int]): Maximum number of messages to return. If None, returns all.
+- `force_refresh` (bool): If True, fetch fresh data from the API.
+
+##### Returns
+
+- `List[ChatMessage]`: List of ChatMessage objects.
+
+##### Raises
+
+- `ChatAuthenticationRequired`: If authentication is required.
+- `ThreadNotFound`: If the thread is not found.
+- `ChatAccessDenied`: If access to the thread is denied.
+
+---
+
+## ChatMessage
+
+The `ChatMessage` class represents a message/reply in a chat thread.
+
+### Class Definition
+
+```python
+ChatMessage(data: Dict[str, Any])
+```
+
+### Parameters
+
+- `data` (Dict[str, Any]): The raw message data from the API, containing 'comment' and 'user' keys.
+
+### Properties
+
+#### `id -> str`
+
+The unique identifier (UUID) for this message.
+
+#### `body -> str`
+
+The text content of the message.
+
+#### `author -> Dict[str, Any]`
+
+The author information dictionary. Contains keys like 'id', 'name', 'handle', 'photo_url'.
+
+#### `created_at -> str`
+
+The ISO timestamp when the message was created.
+
+#### `media_attachments -> List[Dict[str, Any]]`
+
+List of media attachments (images, etc.) in the message.
+
+#### `reaction_count -> int`
+
+The number of reactions on this message.
+
+#### `raw_data -> Dict[str, Any]`
+
+The complete raw data dictionary from the API.
+
+---
+
+## Exceptions
+
+### ChatError
+
+Base exception for chat-related errors. All other chat exceptions inherit from this.
+
+```python
+class ChatError(Exception): pass
+```
+
+### ChatAuthenticationRequired
+
+Raised when authentication is required to access a chat or thread.
+
+```python
+class ChatAuthenticationRequired(ChatError): pass
+```
+
+### ChatAccessDenied
+
+Raised when the user does not have permission to access a chat or thread.
+
+```python
+class ChatAccessDenied(ChatError): pass
+```
+
+### ChatNotFound
+
+Raised when the specified chat/publication is not found.
+
+```python
+class ChatNotFound(ChatError): pass
+```
+
+### ThreadNotFound
+
+Raised when the specified thread is not found.
+
+```python
+class ThreadNotFound(ChatError): pass
+```
+
+---
+
+## Example Usage
+
+### Basic Usage
+
+```python
+from substack_api import Chat, SubstackAuth
+
+# Set up authentication (required for chat access)
+auth = SubstackAuth(cookies_path="cookies.json")
+
+# Access a publication's chat (using publication ID)
+chat = Chat(4906951, auth=auth)
+
+# Get recent threads
+threads = chat.get_threads(limit=5)
+for thread in threads:
+    print(f"Thread: {thread.body[:80]}...")
+    print(f"  By: {thread.author['name']} on {thread.created_at}")
+    print(f"  {thread.comment_count} messages")
+```
+
+### Reading Messages in a Thread
+
+```python
+from substack_api import Chat, SubstackAuth
+
+auth = SubstackAuth(cookies_path="cookies.json")
+chat = Chat(4906951, auth=auth)
+
+# Get threads and read messages
+threads = chat.get_threads(limit=1)
+if threads:
+    thread = threads[0]
+    messages = thread.get_messages()
+
+    for msg in messages:
+        print(f"[{msg.created_at}] {msg.author['name']}: {msg.body[:60]}...")
+
+        # Check for media attachments
+        if msg.media_attachments:
+            print(f"  Attachments: {len(msg.media_attachments)}")
+```
+
+### Accessing a Specific Thread
+
+```python
+from substack_api import Chat, SubstackAuth
+
+auth = SubstackAuth(cookies_path="cookies.json")
+chat = Chat(4906951, auth=auth)
+
+# Get a specific thread by ID
+thread = chat.get_thread("4e1f8bb1-cea6-4bc9-889d-e8856df852d0")
+messages = thread.get_messages()
+
+print(f"Thread has {len(messages)} messages")
+```
+
+### Error Handling
+
+```python
+from substack_api import Chat, SubstackAuth
+from substack_api.chat import (
+    ChatAuthenticationRequired,
+    ChatAccessDenied,
+    ChatNotFound,
+    ThreadNotFound,
+)
+
+auth = SubstackAuth(cookies_path="cookies.json")
+chat = Chat(4906951, auth=auth)
+
+try:
+    threads = chat.get_threads()
+except ChatAuthenticationRequired:
+    print("Authentication required - check your cookies")
+except ChatAccessDenied:
+    print("You don't have access to this chat")
+except ChatNotFound:
+    print("Publication not found")
+```

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -8,6 +8,7 @@ This section provides detailed documentation for all modules and classes in the 
 - [Newsletter](newsletter.md): Access to Substack publications, posts, and podcasts
 - [Post](post.md): Access to individual Substack post content and metadata
 - [Category](category.md): Discovery of newsletters by category
+- [Chat](chat.md): Access to publication subscriber chats and threads
 - [SubstackAuth](auth.md): Authentication for accessing paywalled content
 
 Each module documentation includes:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2,12 +2,13 @@
 
 ## Basic Concepts
 
-The Substack API library is organized around five main classes:
+The Substack API library is organized around these main classes:
 
 - `User` - Represents a Substack user profile
 - `Newsletter` - Represents a Substack publication
 - `Post` - Represents an individual post on Substack
 - `Category` - Represents a Substack category of newsletters
+- `Chat` - Represents a publication's subscriber chat
 - `SubstackAuth` - Handles authentication for accessing paywalled content
 
 Each class provides methods to access different aspects of the Substack ecosystem.
@@ -161,6 +162,65 @@ newsletters = category.get_newsletters()
 
 # Get full metadata for newsletters in this category
 newsletter_metadata = category.get_newsletter_metadata()
+```
+
+## Working with Chats
+
+The `Chat` class allows you to access publication subscriber chats. This feature requires authentication.
+
+```python
+from substack_api import Chat, SubstackAuth
+
+# Set up authentication (required for chat access)
+auth = SubstackAuth(cookies_path="cookies.json")
+
+# Access a publication's chat using its publication ID
+chat = Chat(4906951, auth=auth)
+
+# Get recent threads
+threads = chat.get_threads(limit=5)
+
+for thread in threads:
+    print(f"Thread: {thread.body[:80]}...")
+    print(f"  By: {thread.author['name']} on {thread.created_at}")
+    print(f"  {thread.comment_count} messages")
+```
+
+### Reading Messages in Threads
+
+```python
+from substack_api import Chat, SubstackAuth
+
+auth = SubstackAuth(cookies_path="cookies.json")
+chat = Chat(4906951, auth=auth)
+
+# Get threads and read messages
+threads = chat.get_threads(limit=1)
+if threads:
+    thread = threads[0]
+    messages = thread.get_messages()
+
+    for msg in messages:
+        print(f"[{msg.created_at}] {msg.author['name']}: {msg.body[:60]}...")
+```
+
+### Error Handling for Chats
+
+```python
+from substack_api import Chat, SubstackAuth
+from substack_api.chat import ChatAuthenticationRequired, ChatAccessDenied, ChatNotFound
+
+auth = SubstackAuth(cookies_path="cookies.json")
+chat = Chat(4906951, auth=auth)
+
+try:
+    threads = chat.get_threads()
+except ChatAuthenticationRequired:
+    print("Authentication required - check your cookies")
+except ChatAccessDenied:
+    print("You don't have access to this chat")
+except ChatNotFound:
+    print("Publication not found")
 ```
 
 ## Authentication

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ plugins:
 nav:
   - Home: index.md
   - Installation: installation.md
+  - CLI: cli.md
   - User Guide: user-guide.md
   - Authentication: authentication.md
   - API Reference:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,7 +52,6 @@ plugins:
 nav:
   - Home: index.md
   - Installation: installation.md
-  - CLI: cli.md
   - User Guide: user-guide.md
   - Authentication: authentication.md
   - API Reference:
@@ -61,6 +60,7 @@ nav:
       - Newsletter: api-reference/newsletter.md
       - Post: api-reference/post.md
       - Category: api-reference/category.md
+      - Chat: api-reference/chat.md
       - SubstackAuth: api-reference/auth.md
 
 # Extra CSS

--- a/substack_api/__init__.py
+++ b/substack_api/__init__.py
@@ -2,6 +2,17 @@ from importlib import metadata as _metadata
 
 from .auth import SubstackAuth
 from .category import Category, list_all_categories
+from .chat import (
+    Chat,
+    ChatAccessDenied,
+    ChatAuthenticationRequired,
+    ChatError,
+    ChatMessage,
+    ChatNotFound,
+    ChatPaymentRequired,
+    ChatThread,
+    ThreadNotFound,
+)
 from .newsletter import Newsletter
 from .post import Post
 from .user import User, resolve_handle_redirect
@@ -18,6 +29,15 @@ __all__ = [
     "Category",
     "Newsletter",
     "SubstackAuth",
+    "Chat",
+    "ChatThread",
+    "ChatMessage",
+    "ChatError",
+    "ChatAuthenticationRequired",
+    "ChatAccessDenied",
+    "ChatPaymentRequired",
+    "ChatNotFound",
+    "ThreadNotFound",
     "resolve_handle_redirect",
     "list_all_categories",
     "__version__",

--- a/substack_api/chat.py
+++ b/substack_api/chat.py
@@ -331,6 +331,9 @@ class ChatThread:
         """
         if self._thread_data:
             return self._thread_data.get("user", {})
+        self._fetch_thread_data()
+        if self._thread_data:
+            return self._thread_data.get("user", {})
         return {}
 
     @property
@@ -338,11 +341,17 @@ class ChatThread:
         """The ISO timestamp when the thread was created."""
         if self._thread_data:
             return self._thread_data.get("communityPost", {}).get("created_at", "")
+        self._fetch_thread_data()
+        if self._thread_data:
+            return self._thread_data.get("communityPost", {}).get("created_at", "")
         return ""
 
     @property
     def comment_count(self) -> int:
         """The number of replies/comments in this thread."""
+        if self._thread_data:
+            return self._thread_data.get("communityPost", {}).get("comment_count", 0)
+        self._fetch_thread_data()
         if self._thread_data:
             return self._thread_data.get("communityPost", {}).get("comment_count", 0)
         return 0
@@ -409,6 +418,11 @@ class ChatThread:
         ThreadNotFound
             If the parent reply is not found.
         """
+        if not self.auth or not self.auth.authenticated:
+            raise ChatAuthenticationRequired(
+                "Authentication is required to access sub-replies."
+            )
+
         parent_id = message.id if isinstance(message, ChatMessage) else message
         url = f"{BASE_URL}/community/comments/{parent_id}/comments"
         params = {"order": "asc", "initial": "true"}
@@ -418,6 +432,14 @@ class ChatThread:
         if response.status_code == 401:
             raise ChatAuthenticationRequired(
                 "Authentication is required to access sub-replies."
+            )
+        elif response.status_code == 402:
+            raise ChatPaymentRequired(
+                "Access to this chat requires a paid subscription or a higher subscription tier."
+            )
+        elif response.status_code == 403:
+            raise ChatAccessDenied(
+                "You do not have permission to access this thread."
             )
         elif response.status_code == 404:
             raise ThreadNotFound(
@@ -623,8 +645,9 @@ class Chat:
 
         Notes
         -----
-        This creates a ChatThread object without pre-fetched data.
-        The thread data will be fetched when properties are accessed.
+        This creates a ChatThread without pre-fetched data. All properties
+        (``body``, ``author``, ``created_at``, ``comment_count``) fetch from
+        the API on first access and cache the result.
         """
         return ChatThread(
             publication_id=self._publication_id,

--- a/substack_api/chat.py
+++ b/substack_api/chat.py
@@ -251,11 +251,37 @@ class ChatThread:
             raise ThreadNotFound(f"Thread with ID '{self.thread_id}' was not found.")
 
         response.raise_for_status()
-        self._messages_data = response.json()
+        data = response.json()
 
-        # Also update thread data from the response if available
-        if "post" in self._messages_data and self._thread_data is None:
-            self._thread_data = self._messages_data["post"]
+        if "post" in data and self._thread_data is None:
+            self._thread_data = data["post"]
+
+        # Paginate backwards (older messages not included in the initial window)
+        all_replies = list(data.get("replies", []))
+        while data.get("moreBefore") and all_replies:
+            r = self.auth.get(
+                url,
+                params={"order": "asc", "before_id": all_replies[0]["comment"]["id"]},
+                timeout=30,
+            )
+            r.raise_for_status()
+            data = r.json()
+            all_replies = data.get("replies", []) + all_replies
+
+        # Paginate forwards (in case the initial window is not at the latest end)
+        data = response.json()
+        while data.get("moreAfter") and all_replies:
+            r = self.auth.get(
+                url,
+                params={"order": "asc", "after_id": all_replies[-1]["comment"]["id"]},
+                timeout=30,
+            )
+            r.raise_for_status()
+            data = r.json()
+            all_replies = all_replies + data.get("replies", [])
+
+        self._messages_data = response.json()
+        self._messages_data["replies"] = all_replies
 
         return self._messages_data
 

--- a/substack_api/chat.py
+++ b/substack_api/chat.py
@@ -1,0 +1,520 @@
+"""
+Substack Chat module for accessing publication subscriber chats.
+
+This module provides classes for interacting with Substack's community chat features,
+including reading threads and messages from publication chats.
+"""
+
+import requests
+from typing import Any, Dict, List, Optional, Union
+
+from substack_api.auth import SubstackAuth
+
+BASE_URL = "https://substack.com/api/v1"
+SEARCH_URL = "https://substack.com/api/v1/publication/search"
+_DISCOVERY_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36",
+    "Accept": "application/json",
+    "Origin": "https://substack.com",
+    "Referer": "https://substack.com/discover",
+}
+
+
+def _resolve_subdomain_to_id(subdomain: str) -> Optional[int]:
+    """Resolve a publication subdomain to its numeric ID.
+
+    Tries the Substack search API first; if that yields no match, falls back to
+    fetching a single post from the publication's own API and reading the
+    publication_id field from the response.
+    """
+    params = {
+        "query": f"{subdomain}.substack.com",
+        "page": 0,
+        "limit": 25,
+        "skipExplanation": "true",
+        "sort": "relevance",
+    }
+    r = requests.get(SEARCH_URL, headers=_DISCOVERY_HEADERS, params=params, timeout=30)
+    r.raise_for_status()
+    for item in r.json().get("publications", []):
+        if item.get("subdomain", "").lower() == subdomain.lower():
+            return item.get("id")
+
+    # Fall back to the publication's own posts endpoint
+    r = requests.get(
+        f"https://{subdomain}.substack.com/api/v1/posts",
+        headers=_DISCOVERY_HEADERS,
+        params={"limit": 1},
+        timeout=30,
+    )
+    if r.status_code == 200:
+        posts = r.json()
+        if posts and isinstance(posts, list):
+            return posts[0].get("publication_id")
+    return None
+
+
+# Exceptions
+class ChatError(Exception):
+    """Base exception for chat-related errors."""
+
+    pass
+
+
+class ChatAuthenticationRequired(ChatError):
+    """Raised when authentication is required to access a chat."""
+
+    pass
+
+
+class ChatAccessDenied(ChatError):
+    """Raised when the user does not have permission to access a chat."""
+
+    pass
+
+
+class ChatPaymentRequired(ChatAccessDenied):
+    """Raised when chat access requires a paid subscription or a higher subscription tier."""
+
+    pass
+
+
+class ChatNotFound(ChatError):
+    """Raised when the specified chat/publication is not found."""
+
+    pass
+
+
+class ThreadNotFound(ChatError):
+    """Raised when the specified thread is not found."""
+
+    pass
+
+
+class ChatMessage:
+    """
+    Represents a message/reply in a chat thread.
+
+    This is a lightweight wrapper around the message data dictionary
+    returned from the Substack API.
+    """
+
+    def __init__(self, data: Dict[str, Any]) -> None:
+        """
+        Initialize a ChatMessage.
+
+        Parameters
+        ----------
+        data : Dict[str, Any]
+            The raw message data from the API, containing 'comment' and 'user' keys.
+        """
+        self._data = data
+
+    def __str__(self) -> str:
+        return f"ChatMessage(id={self.id})"
+
+    def __repr__(self) -> str:
+        return f"ChatMessage(id={self.id}, author={self.author.get('name', 'Unknown')})"
+
+    @property
+    def id(self) -> str:
+        """The unique identifier (UUID) for this message."""
+        return self._data["comment"]["id"]
+
+    @property
+    def body(self) -> str:
+        """The text content of the message."""
+        return self._data["comment"]["body"]
+
+    @property
+    def author(self) -> Dict[str, Any]:
+        """
+        The author information dictionary.
+
+        Contains keys like 'id', 'name', 'handle', 'photo_url'.
+        """
+        return self._data.get("user", {})
+
+    @property
+    def created_at(self) -> str:
+        """The ISO timestamp when the message was created."""
+        return self._data["comment"]["created_at"]
+
+    @property
+    def media_attachments(self) -> List[Dict[str, Any]]:
+        """List of media attachments (images, etc.) in the message."""
+        return self._data["comment"].get("mediaAttachments", [])
+
+    @property
+    def reaction_count(self) -> int:
+        """The number of reactions on this message."""
+        return self._data["comment"].get("reaction_count", 0)
+
+    @property
+    def raw_data(self) -> Dict[str, Any]:
+        """The complete raw data dictionary from the API."""
+        return self._data
+
+
+class ChatThread:
+    """
+    Represents a thread within a publication chat.
+
+    A thread is a top-level post in the chat that can contain multiple
+    message replies.
+    """
+
+    def __init__(
+        self,
+        publication_id: Union[str, int],
+        thread_id: str,
+        auth: SubstackAuth,
+        _data: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Initialize a ChatThread.
+
+        Parameters
+        ----------
+        publication_id : Union[str, int]
+            The publication ID this thread belongs to.
+        thread_id : str
+            The unique identifier (UUID) for this thread.
+        auth : SubstackAuth
+            Authentication handler for API requests.
+        _data : Optional[Dict[str, Any]]
+            Pre-fetched thread data (for internal use).
+        """
+        self.publication_id = (
+            int(publication_id) if isinstance(publication_id, str) else publication_id
+        )
+        self.thread_id = thread_id
+        self.auth = auth
+        self._thread_data = _data
+        self._messages_data: Optional[Dict[str, Any]] = None
+
+    def __str__(self) -> str:
+        return f"ChatThread(id={self.thread_id})"
+
+    def __repr__(self) -> str:
+        return f"ChatThread(publication_id={self.publication_id}, thread_id={self.thread_id})"
+
+    def _fetch_thread_data(self, force_refresh: bool = False) -> Dict[str, Any]:
+        """
+        Fetch thread data including messages from the API.
+
+        Parameters
+        ----------
+        force_refresh : bool
+            If True, fetch fresh data even if cached data exists.
+
+        Returns
+        -------
+        Dict[str, Any]
+            The full thread data including replies.
+
+        Raises
+        ------
+        ChatAuthenticationRequired
+            If authentication is required.
+        ThreadNotFound
+            If the thread is not found.
+        ChatAccessDenied
+            If access to the thread is denied.
+        """
+        if self._messages_data is not None and not force_refresh:
+            return self._messages_data
+
+        if not self.auth or not self.auth.authenticated:
+            raise ChatAuthenticationRequired(
+                "Authentication is required to access chat threads."
+            )
+
+        url = f"{BASE_URL}/community/posts/{self.thread_id}/comments"
+        params = {"order": "asc", "initial": "true"}
+
+        response = self.auth.get(url, params=params, timeout=30)
+
+        if response.status_code == 401:
+            raise ChatAuthenticationRequired(
+                "Authentication is required to access this thread."
+            )
+        elif response.status_code == 402:
+            raise ChatPaymentRequired(
+                "Access to this thread requires a paid subscription or a higher subscription tier."
+            )
+        elif response.status_code == 403:
+            raise ChatAccessDenied(
+                "You do not have permission to access this thread."
+            )
+        elif response.status_code == 404:
+            raise ThreadNotFound(f"Thread with ID '{self.thread_id}' was not found.")
+
+        response.raise_for_status()
+        self._messages_data = response.json()
+
+        # Also update thread data from the response if available
+        if "post" in self._messages_data and self._thread_data is None:
+            self._thread_data = self._messages_data["post"]
+
+        return self._messages_data
+
+    @property
+    def id(self) -> str:
+        """The unique identifier (UUID) for this thread."""
+        return self.thread_id
+
+    @property
+    def body(self) -> str:
+        """The text content of the thread's original post."""
+        if self._thread_data:
+            return self._thread_data.get("communityPost", {}).get("body", "")
+        # Fetch if needed
+        self._fetch_thread_data()
+        if self._thread_data:
+            return self._thread_data.get("communityPost", {}).get("body", "")
+        return ""
+
+    @property
+    def author(self) -> Dict[str, Any]:
+        """
+        The author information dictionary.
+
+        Contains keys like 'id', 'name', 'handle', 'photo_url'.
+        """
+        if self._thread_data:
+            return self._thread_data.get("user", {})
+        return {}
+
+    @property
+    def created_at(self) -> str:
+        """The ISO timestamp when the thread was created."""
+        if self._thread_data:
+            return self._thread_data.get("communityPost", {}).get("created_at", "")
+        return ""
+
+    @property
+    def comment_count(self) -> int:
+        """The number of replies/comments in this thread."""
+        if self._thread_data:
+            return self._thread_data.get("communityPost", {}).get("comment_count", 0)
+        return 0
+
+    @property
+    def raw_data(self) -> Optional[Dict[str, Any]]:
+        """The raw thread data dictionary from the API."""
+        return self._thread_data
+
+    def get_messages(
+        self, limit: Optional[int] = None, force_refresh: bool = False
+    ) -> List[ChatMessage]:
+        """
+        Get all messages/replies in this thread.
+
+        Parameters
+        ----------
+        limit : Optional[int]
+            Client-side truncation of the first page of results returned by the
+            API. The full page is always fetched; this just slices the list.
+            If None, returns all messages from the page.
+        force_refresh : bool
+            If True, fetch fresh data from the API.
+
+        Returns
+        -------
+        List[ChatMessage]
+            List of ChatMessage objects.
+
+        Raises
+        ------
+        ChatAuthenticationRequired
+            If authentication is required.
+        ThreadNotFound
+            If the thread is not found.
+        """
+        data = self._fetch_thread_data(force_refresh=force_refresh)
+        messages = [ChatMessage(reply) for reply in data.get("replies", [])]
+
+        if limit is not None:
+            return messages[:limit]
+        return messages
+
+
+class Chat:
+    """
+    Represents a publication's community chat.
+
+    Use this class to access threads and messages in a Substack publication's
+    subscriber chat.
+    """
+
+    def __init__(
+        self,
+        publication_id: Union[str, int],
+        auth: SubstackAuth,
+    ) -> None:
+        """
+        Initialize a Chat.
+
+        Parameters
+        ----------
+        publication_id : Union[str, int]
+            The numeric publication ID, or a subdomain string (e.g. ``"platformer"``
+            for ``platformer.substack.com``). If a non-numeric string is given it is
+            resolved to a numeric ID via the Substack search API.
+        auth : SubstackAuth
+            Authentication handler for API requests.
+
+        Raises
+        ------
+        ValueError
+            If a subdomain string is given but cannot be resolved to a publication ID.
+        """
+        if isinstance(publication_id, str):
+            try:
+                self._publication_id = int(publication_id)
+            except ValueError:
+                resolved = _resolve_subdomain_to_id(publication_id)
+                if resolved is None:
+                    raise ValueError(
+                        f"Could not resolve subdomain '{publication_id}' to a publication ID."
+                    )
+                self._publication_id = resolved
+        else:
+            self._publication_id = publication_id
+        self.auth = auth
+        self._threads_data: Optional[Dict[str, Any]] = None
+
+    def __str__(self) -> str:
+        return f"Chat(publication_id={self._publication_id})"
+
+    def __repr__(self) -> str:
+        return f"Chat(publication_id={self._publication_id})"
+
+    @property
+    def publication_id(self) -> int:
+        """The publication ID for this chat."""
+        return self._publication_id
+
+    def _fetch_threads_data(self, force_refresh: bool = False) -> Dict[str, Any]:
+        """
+        Fetch threads data from the API.
+
+        Parameters
+        ----------
+        force_refresh : bool
+            If True, fetch fresh data even if cached data exists.
+
+        Returns
+        -------
+        Dict[str, Any]
+            The threads data from the API.
+
+        Raises
+        ------
+        ChatAuthenticationRequired
+            If authentication is required.
+        ChatNotFound
+            If the publication is not found.
+        ChatAccessDenied
+            If access to the chat is denied.
+        """
+        if self._threads_data is not None and not force_refresh:
+            return self._threads_data
+
+        if not self.auth or not self.auth.authenticated:
+            raise ChatAuthenticationRequired(
+                "Authentication is required to access publication chats."
+            )
+
+        url = f"{BASE_URL}/community/publications/{self._publication_id}/posts"
+
+        response = self.auth.get(url, timeout=30)
+
+        if response.status_code == 401:
+            raise ChatAuthenticationRequired(
+                "Authentication is required to access this chat."
+            )
+        elif response.status_code == 402:
+            raise ChatPaymentRequired(
+                "Access to this chat requires a paid subscription or a higher subscription tier."
+            )
+        elif response.status_code == 403:
+            raise ChatAccessDenied(
+                "You do not have permission to access this publication's chat."
+            )
+        elif response.status_code == 404:
+            raise ChatNotFound(
+                f"Publication with ID '{self._publication_id}' was not found."
+            )
+
+        response.raise_for_status()
+        self._threads_data = response.json()
+        return self._threads_data
+
+    def get_threads(
+        self, limit: Optional[int] = None, force_refresh: bool = False
+    ) -> List[ChatThread]:
+        """
+        Get threads from the publication chat.
+
+        Parameters
+        ----------
+        limit : Optional[int]
+            Client-side truncation of the first page of results returned by the
+            API. The full page is always fetched; this just slices the list.
+            If None, returns all threads from the page.
+        force_refresh : bool
+            If True, fetch fresh data from the API.
+
+        Returns
+        -------
+        List[ChatThread]
+            List of ChatThread objects.
+
+        Raises
+        ------
+        ChatAuthenticationRequired
+            If authentication is required.
+        ChatNotFound
+            If the publication is not found.
+        """
+        data = self._fetch_threads_data(force_refresh=force_refresh)
+        threads = [
+            ChatThread(
+                publication_id=self._publication_id,
+                thread_id=t["communityPost"]["id"],
+                auth=self.auth,
+                _data=t,
+            )
+            for t in data.get("threads", [])
+        ]
+
+        if limit is not None:
+            return threads[:limit]
+        return threads
+
+    def get_thread(self, thread_id: str) -> ChatThread:
+        """
+        Get a specific thread by its ID.
+
+        Parameters
+        ----------
+        thread_id : str
+            The UUID of the thread to retrieve.
+
+        Returns
+        -------
+        ChatThread
+            The ChatThread object for the specified thread.
+
+        Notes
+        -----
+        This creates a ChatThread object without pre-fetched data.
+        The thread data will be fetched when properties are accessed.
+        """
+        return ChatThread(
+            publication_id=self._publication_id,
+            thread_id=thread_id,
+            auth=self.auth,
+        )

--- a/substack_api/chat.py
+++ b/substack_api/chat.py
@@ -151,6 +151,27 @@ class ChatMessage:
         return self._data["comment"].get("reaction_count", 0)
 
     @property
+    def reply_count(self) -> int:
+        """The number of sub-replies on this message."""
+        return self._data["comment"].get("reply_count", 0)
+
+    @property
+    def pub_roles(self) -> Optional[Dict[str, Any]]:
+        """
+        Publication role information for the message author.
+
+        Returns a dict with a ``role`` key; ``role == 'admin'`` indicates the
+        publication owner.  ``None`` means role data is not available.
+        """
+        return self._data.get("pub_roles")
+
+    @property
+    def is_owner(self) -> bool:
+        """True if the author is the publication owner (pub_roles.role == 'admin')."""
+        pr = self._data.get("pub_roles") or {}
+        return pr.get("role") == "admin"
+
+    @property
     def raw_data(self) -> Dict[str, Any]:
         """The complete raw data dictionary from the API."""
         return self._data
@@ -364,6 +385,72 @@ class ChatThread:
         if limit is not None:
             return messages[:limit]
         return messages
+
+    def get_sub_replies(
+        self, message: Union[str, "ChatMessage"]
+    ) -> List[ChatMessage]:
+        """
+        Get sub-replies for a top-level reply in this thread.
+
+        Parameters
+        ----------
+        message : Union[str, ChatMessage]
+            The parent reply: either a ChatMessage object or its UUID string.
+
+        Returns
+        -------
+        List[ChatMessage]
+            Sub-replies in ascending chronological order.
+
+        Raises
+        ------
+        ChatAuthenticationRequired
+            If authentication is required.
+        ThreadNotFound
+            If the parent reply is not found.
+        """
+        parent_id = message.id if isinstance(message, ChatMessage) else message
+        url = f"{BASE_URL}/community/comments/{parent_id}/comments"
+        params = {"order": "asc", "initial": "true"}
+
+        response = self.auth.get(url, params=params, timeout=30)
+
+        if response.status_code == 401:
+            raise ChatAuthenticationRequired(
+                "Authentication is required to access sub-replies."
+            )
+        elif response.status_code == 404:
+            raise ThreadNotFound(
+                f"Parent reply with ID '{parent_id}' was not found."
+            )
+
+        response.raise_for_status()
+        data = response.json()
+
+        all_replies = list(data.get("replies", []))
+
+        while data.get("moreBefore") and all_replies:
+            r = self.auth.get(
+                url,
+                params={"order": "asc", "before_id": all_replies[0]["comment"]["id"]},
+                timeout=30,
+            )
+            r.raise_for_status()
+            data = r.json()
+            all_replies = data.get("replies", []) + all_replies
+
+        data = response.json()
+        while data.get("moreAfter") and all_replies:
+            r = self.auth.get(
+                url,
+                params={"order": "asc", "after_id": all_replies[-1]["comment"]["id"]},
+                timeout=30,
+            )
+            r.raise_for_status()
+            data = r.json()
+            all_replies = all_replies + data.get("replies", [])
+
+        return [ChatMessage(reply) for reply in all_replies]
 
 
 class Chat:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -669,3 +669,182 @@ class TestIntegration:
         assert first_message.id is not None
         assert first_message.body is not None
         assert first_message.created_at is not None
+
+
+# ============================================================
+# New property tests: reply_count, is_owner, pub_roles
+# ============================================================
+
+
+class TestChatMessageNewProperties:
+    def _make_message(self, pub_roles=None, reply_count=0):
+        return ChatMessage({
+            "comment": {
+                "id": "test-id",
+                "body": "Test body",
+                "created_at": "2026-01-20T14:39:02.189Z",
+                "mediaAttachments": [],
+                "reaction_count": 0,
+                "reply_count": reply_count,
+            },
+            "user": {"id": 1, "name": "Test User", "handle": "testuser"},
+            "pub_roles": pub_roles,
+        })
+
+    def test_reply_count_zero(self):
+        msg = self._make_message(reply_count=0)
+        assert msg.reply_count == 0
+
+    def test_reply_count_nonzero(self):
+        msg = self._make_message(reply_count=5)
+        assert msg.reply_count == 5
+
+    def test_is_owner_true(self):
+        msg = self._make_message(pub_roles={"role": "admin"})
+        assert msg.is_owner is True
+
+    def test_is_owner_false_subscriber(self):
+        msg = self._make_message(pub_roles={"role": None})
+        assert msg.is_owner is False
+
+    def test_is_owner_false_no_pub_roles(self):
+        msg = self._make_message(pub_roles=None)
+        assert msg.is_owner is False
+
+    def test_pub_roles_present(self):
+        roles = {"role": "admin", "membership_state": "subscribed"}
+        msg = self._make_message(pub_roles=roles)
+        assert msg.pub_roles == roles
+
+    def test_pub_roles_none(self):
+        msg = self._make_message(pub_roles=None)
+        assert msg.pub_roles is None
+
+
+# ============================================================
+# get_sub_replies tests
+# ============================================================
+
+
+class TestGetSubReplies:
+    def _sub_reply_data(self, reply_id, parent_id, body):
+        return {
+            "comment": {
+                "id": reply_id,
+                "body": body,
+                "created_at": "2026-01-20T15:00:00.000Z",
+                "mediaAttachments": [],
+                "reaction_count": 0,
+                "reply_count": 0,
+                "parent_id": parent_id,
+            },
+            "user": {"id": 99, "name": "Replier", "handle": "replier"},
+            "pub_roles": None,
+        }
+
+    def test_get_sub_replies_by_string_id(self, mock_auth):
+        parent_id = "parent-uuid-1"
+        sub_data = {
+            "post": {},
+            "parent": {},
+            "replies": [
+                self._sub_reply_data("sub-1", parent_id, "Sub-reply A"),
+                self._sub_reply_data("sub-2", parent_id, "Sub-reply B"),
+            ],
+            "moreAfter": False,
+            "moreBefore": False,
+        }
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = sub_data
+        mock_auth.get.return_value = mock_response
+
+        thread = ChatThread(publication_id=1234, thread_id="thread-uuid", auth=mock_auth)
+        sub_replies = thread.get_sub_replies(parent_id)
+
+        assert len(sub_replies) == 2
+        assert all(isinstance(sr, ChatMessage) for sr in sub_replies)
+        assert sub_replies[0].id == "sub-1"
+        assert sub_replies[1].id == "sub-2"
+        # Verify the correct endpoint was called
+        call_url = mock_auth.get.call_args[0][0]
+        assert f"/community/comments/{parent_id}/comments" in call_url
+
+    def test_get_sub_replies_by_chat_message(self, mock_auth):
+        parent_id = "parent-uuid-2"
+        parent_message = ChatMessage({
+            "comment": {"id": parent_id, "body": "Parent", "created_at": "2026-01-20T14:00:00.000Z",
+                        "mediaAttachments": [], "reaction_count": 0, "reply_count": 1},
+            "user": {"id": 1, "name": "Author", "handle": "author"},
+            "pub_roles": None,
+        })
+        sub_data = {
+            "replies": [self._sub_reply_data("sub-only", parent_id, "Only sub-reply")],
+            "moreAfter": False,
+            "moreBefore": False,
+        }
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = sub_data
+        mock_auth.get.return_value = mock_response
+
+        thread = ChatThread(publication_id=1234, thread_id="thread-uuid", auth=mock_auth)
+        sub_replies = thread.get_sub_replies(parent_message)
+
+        assert len(sub_replies) == 1
+        assert sub_replies[0].body == "Only sub-reply"
+        call_url = mock_auth.get.call_args[0][0]
+        assert f"/community/comments/{parent_id}/comments" in call_url
+
+    def test_get_sub_replies_401_raises(self, mock_auth):
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_auth.get.return_value = mock_response
+
+        thread = ChatThread(publication_id=1234, thread_id="thread-uuid", auth=mock_auth)
+        with pytest.raises(ChatAuthenticationRequired):
+            thread.get_sub_replies("some-parent-id")
+
+    def test_get_sub_replies_404_raises(self, mock_auth):
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_auth.get.return_value = mock_response
+
+        thread = ChatThread(publication_id=1234, thread_id="thread-uuid", auth=mock_auth)
+        with pytest.raises(ThreadNotFound):
+            thread.get_sub_replies("nonexistent-parent-id")
+
+    def test_get_sub_replies_paginates_after(self, mock_auth):
+        parent_id = "parent-uuid-3"
+        page1 = {
+            "replies": [self._sub_reply_data("sub-a", parent_id, "Sub A")],
+            "moreAfter": True,
+            "moreBefore": False,
+        }
+        page2 = {
+            "replies": [self._sub_reply_data("sub-b", parent_id, "Sub B")],
+            "moreAfter": False,
+            "moreBefore": False,
+        }
+
+        call_count = {"n": 0}
+
+        def side_effect(url, params=None, timeout=None):
+            call_count["n"] += 1
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            if params and "after_id" in params:
+                mock_response.json.return_value = page2
+            else:
+                mock_response.json.return_value = page1
+            return mock_response
+
+        mock_auth.get.side_effect = side_effect
+
+        thread = ChatThread(publication_id=1234, thread_id="thread-uuid", auth=mock_auth)
+        sub_replies = thread.get_sub_replies(parent_id)
+
+        assert len(sub_replies) == 2
+        assert sub_replies[0].id == "sub-a"
+        assert sub_replies[1].id == "sub-b"
+        assert call_count["n"] == 2

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,634 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from substack_api.chat import (
+    Chat,
+    ChatAccessDenied,
+    ChatAuthenticationRequired,
+    ChatError,
+    ChatMessage,
+    ChatNotFound,
+    ChatPaymentRequired,
+    ChatThread,
+    ThreadNotFound,
+)
+
+
+@pytest.fixture
+def sample_threads_data():
+    return {
+        "threads": [
+            {
+                "communityPost": {
+                    "id": "test-thread-uuid-1",
+                    "created_at": "2026-01-20T14:32:07.059Z",
+                    "body": "Test thread body content",
+                    "comment_count": 5,
+                    "user_id": 12345,
+                },
+                "user": {
+                    "id": 12345,
+                    "name": "Test User",
+                    "handle": "testuser",
+                    "photo_url": "https://example.com/photo.jpg",
+                },
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def sample_comments_data():
+    return {
+        "post": {
+            "communityPost": {
+                "id": "test-thread-uuid-1",
+                "body": "Test thread body",
+                "comment_count": 2,
+            },
+            "user": {"id": 12345, "name": "Test User"},
+        },
+        "replies": [
+            {
+                "comment": {
+                    "id": "message-uuid-1",
+                    "body": "First reply message",
+                    "created_at": "2026-01-20T14:39:02.189Z",
+                    "mediaAttachments": [],
+                    "reaction_count": 0,
+                },
+                "user": {"id": 12345, "name": "Test User", "handle": "testuser"},
+            },
+            {
+                "comment": {
+                    "id": "message-uuid-2",
+                    "body": "Second reply message",
+                    "created_at": "2026-01-20T15:00:00.000Z",
+                    "mediaAttachments": [{"type": "image", "url": "https://example.com/img.png"}],
+                    "reaction_count": 2,
+                },
+                "user": {"id": 67890, "name": "Another User", "handle": "another"},
+            },
+        ],
+        "more": False,
+    }
+
+
+@pytest.fixture
+def mock_auth():
+    """Create a mock authenticated SubstackAuth object."""
+    auth = MagicMock()
+    auth.authenticated = True
+    return auth
+
+
+@pytest.fixture
+def mock_unauth():
+    """Create a mock unauthenticated SubstackAuth object."""
+    auth = MagicMock()
+    auth.authenticated = False
+    return auth
+
+
+# ============================================================
+# ChatMessage Tests
+# ============================================================
+
+
+class TestChatMessage:
+    def test_init(self, sample_comments_data):
+        """Test ChatMessage initialization."""
+        reply_data = sample_comments_data["replies"][0]
+        message = ChatMessage(reply_data)
+        assert message._data == reply_data
+
+    def test_id_property(self, sample_comments_data):
+        """Test ChatMessage.id property."""
+        reply_data = sample_comments_data["replies"][0]
+        message = ChatMessage(reply_data)
+        assert message.id == reply_data["comment"]["id"]
+
+    def test_body_property(self, sample_comments_data):
+        """Test ChatMessage.body property."""
+        reply_data = sample_comments_data["replies"][0]
+        message = ChatMessage(reply_data)
+        assert message.body == reply_data["comment"]["body"]
+
+    def test_author_property(self, sample_comments_data):
+        """Test ChatMessage.author property."""
+        reply_data = sample_comments_data["replies"][0]
+        message = ChatMessage(reply_data)
+        assert message.author == reply_data["user"]
+        assert "name" in message.author
+        assert "handle" in message.author
+
+    def test_created_at_property(self, sample_comments_data):
+        """Test ChatMessage.created_at property."""
+        reply_data = sample_comments_data["replies"][0]
+        message = ChatMessage(reply_data)
+        assert message.created_at == reply_data["comment"]["created_at"]
+
+    def test_media_attachments_property(self, sample_comments_data):
+        """Test ChatMessage.media_attachments property."""
+        # Test message with attachments
+        reply_with_media = sample_comments_data["replies"][1]
+        message = ChatMessage(reply_with_media)
+        assert message.media_attachments == reply_with_media["comment"]["mediaAttachments"]
+
+    def test_media_attachments_empty(self):
+        """Test ChatMessage.media_attachments returns empty list when none."""
+        # Create minimal data with no attachments
+        reply_data = {
+            "comment": {
+                "id": "test-id",
+                "body": "Test message",
+                "created_at": "2026-01-20T14:39:02.189Z",
+                "reaction_count": 0,
+            },
+            "user": {"id": 12345, "name": "Test User", "handle": "testuser"},
+        }
+        message = ChatMessage(reply_data)
+        assert message.media_attachments == []
+
+    def test_reaction_count_property(self, sample_comments_data):
+        """Test ChatMessage.reaction_count property."""
+        reply_data = sample_comments_data["replies"][0]
+        message = ChatMessage(reply_data)
+        assert message.reaction_count == reply_data["comment"].get("reaction_count", 0)
+
+    def test_raw_data_property(self, sample_comments_data):
+        """Test ChatMessage.raw_data property returns full data."""
+        reply_data = sample_comments_data["replies"][0]
+        message = ChatMessage(reply_data)
+        assert message.raw_data == reply_data
+
+    def test_str_repr(self, sample_comments_data):
+        """Test ChatMessage string representations."""
+        reply_data = sample_comments_data["replies"][0]
+        message = ChatMessage(reply_data)
+        assert reply_data["comment"]["id"] in str(message)
+        assert reply_data["comment"]["id"] in repr(message)
+
+
+# ============================================================
+# ChatThread Tests
+# ============================================================
+
+
+class TestChatThread:
+    def test_init(self, mock_auth):
+        """Test ChatThread initialization."""
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id="test-uuid",
+            auth=mock_auth,
+        )
+        assert thread.publication_id == 4906951
+        assert thread.thread_id == "test-uuid"
+        assert thread.auth == mock_auth
+        assert thread._thread_data is None
+
+    def test_init_with_string_publication_id(self, mock_auth):
+        """Test ChatThread initialization with string publication_id."""
+        thread = ChatThread(
+            publication_id="4906951",
+            thread_id="test-uuid",
+            auth=mock_auth,
+        )
+        assert thread.publication_id == 4906951
+        assert isinstance(thread.publication_id, int)
+
+    def test_init_with_data(self, mock_auth, sample_threads_data):
+        """Test ChatThread initialization with pre-fetched data."""
+        thread_data = sample_threads_data["threads"][0]
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id=thread_data["communityPost"]["id"],
+            auth=mock_auth,
+            _data=thread_data,
+        )
+        assert thread._thread_data == thread_data
+
+    def test_id_property(self, mock_auth):
+        """Test ChatThread.id property returns thread_id."""
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id="test-uuid-123",
+            auth=mock_auth,
+        )
+        assert thread.id == "test-uuid-123"
+
+    def test_body_property_with_data(self, mock_auth, sample_threads_data):
+        """Test ChatThread.body property when data is pre-loaded."""
+        thread_data = sample_threads_data["threads"][0]
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id=thread_data["communityPost"]["id"],
+            auth=mock_auth,
+            _data=thread_data,
+        )
+        assert thread.body == thread_data["communityPost"]["body"]
+
+    def test_author_property_with_data(self, mock_auth, sample_threads_data):
+        """Test ChatThread.author property when data is pre-loaded."""
+        thread_data = sample_threads_data["threads"][0]
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id=thread_data["communityPost"]["id"],
+            auth=mock_auth,
+            _data=thread_data,
+        )
+        assert thread.author == thread_data["user"]
+
+    def test_created_at_property_with_data(self, mock_auth, sample_threads_data):
+        """Test ChatThread.created_at property when data is pre-loaded."""
+        thread_data = sample_threads_data["threads"][0]
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id=thread_data["communityPost"]["id"],
+            auth=mock_auth,
+            _data=thread_data,
+        )
+        assert thread.created_at == thread_data["communityPost"]["created_at"]
+
+    def test_comment_count_property_with_data(self, mock_auth, sample_threads_data):
+        """Test ChatThread.comment_count property when data is pre-loaded."""
+        thread_data = sample_threads_data["threads"][0]
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id=thread_data["communityPost"]["id"],
+            auth=mock_auth,
+            _data=thread_data,
+        )
+        assert thread.comment_count == thread_data["communityPost"]["comment_count"]
+
+    def test_get_messages(self, mock_auth, sample_comments_data):
+        """Test ChatThread.get_messages returns list of ChatMessage objects."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = sample_comments_data
+        mock_auth.get.return_value = mock_response
+
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id="test-uuid",
+            auth=mock_auth,
+        )
+        messages = thread.get_messages()
+
+        assert len(messages) == len(sample_comments_data["replies"])
+        assert all(isinstance(m, ChatMessage) for m in messages)
+        mock_auth.get.assert_called_once()
+
+    def test_get_messages_with_limit(self, mock_auth, sample_comments_data):
+        """Test ChatThread.get_messages respects limit parameter."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = sample_comments_data
+        mock_auth.get.return_value = mock_response
+
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id="test-uuid",
+            auth=mock_auth,
+        )
+        messages = thread.get_messages(limit=1)
+
+        assert len(messages) == 1
+
+    def test_get_messages_caching(self, mock_auth, sample_comments_data):
+        """Test ChatThread.get_messages uses cached data."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = sample_comments_data
+        mock_auth.get.return_value = mock_response
+
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id="test-uuid",
+            auth=mock_auth,
+        )
+
+        # First call - should fetch
+        thread.get_messages()
+        assert mock_auth.get.call_count == 1
+
+        # Second call - should use cache
+        thread.get_messages()
+        assert mock_auth.get.call_count == 1
+
+        # Force refresh - should fetch again
+        thread.get_messages(force_refresh=True)
+        assert mock_auth.get.call_count == 2
+
+    def test_get_messages_unauthenticated(self, mock_unauth):
+        """Test ChatThread.get_messages raises error when not authenticated."""
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id="test-uuid",
+            auth=mock_unauth,
+        )
+
+        with pytest.raises(ChatAuthenticationRequired):
+            thread.get_messages()
+
+    def test_get_messages_401_response(self, mock_auth):
+        """Test ChatThread.get_messages handles 401 response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_auth.get.return_value = mock_response
+
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id="test-uuid",
+            auth=mock_auth,
+        )
+
+        with pytest.raises(ChatAuthenticationRequired):
+            thread.get_messages()
+
+    def test_get_messages_402_response(self, mock_auth):
+        """Test ChatThread.get_messages handles 402 response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 402
+        mock_auth.get.return_value = mock_response
+
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id="test-uuid",
+            auth=mock_auth,
+        )
+
+        with pytest.raises(ChatPaymentRequired):
+            thread.get_messages()
+
+    def test_get_messages_403_response(self, mock_auth):
+        """Test ChatThread.get_messages handles 403 response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_auth.get.return_value = mock_response
+
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id="test-uuid",
+            auth=mock_auth,
+        )
+
+        with pytest.raises(ChatAccessDenied):
+            thread.get_messages()
+
+    def test_get_messages_404_response(self, mock_auth):
+        """Test ChatThread.get_messages handles 404 response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_auth.get.return_value = mock_response
+
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id="test-uuid",
+            auth=mock_auth,
+        )
+
+        with pytest.raises(ThreadNotFound):
+            thread.get_messages()
+
+    def test_str_repr(self, mock_auth):
+        """Test ChatThread string representations."""
+        thread = ChatThread(
+            publication_id=4906951,
+            thread_id="test-uuid-123",
+            auth=mock_auth,
+        )
+        assert "test-uuid-123" in str(thread)
+        assert "4906951" in repr(thread)
+        assert "test-uuid-123" in repr(thread)
+
+
+# ============================================================
+# Chat Tests
+# ============================================================
+
+
+class TestChat:
+    def test_init(self, mock_auth):
+        """Test Chat initialization."""
+        chat = Chat(publication_id=4906951, auth=mock_auth)
+        assert chat.publication_id == 4906951
+        assert chat.auth == mock_auth
+        assert chat._threads_data is None
+
+    def test_init_with_string_publication_id(self, mock_auth):
+        """Test Chat initialization with numeric string publication_id."""
+        chat = Chat(publication_id="4906951", auth=mock_auth)
+        assert chat.publication_id == 4906951
+        assert isinstance(chat.publication_id, int)
+
+    def test_init_with_subdomain(self, mock_auth, monkeypatch):
+        """Test Chat initialization with a subdomain string."""
+        from substack_api import chat as chat_module
+        monkeypatch.setattr(chat_module, "_resolve_subdomain_to_id", lambda s: 4906951)
+        c = Chat(publication_id="platformer", auth=mock_auth)
+        assert c.publication_id == 4906951
+
+    def test_init_with_unresolvable_subdomain(self, mock_auth, monkeypatch):
+        """Test Chat raises ValueError when subdomain cannot be resolved."""
+        from substack_api import chat as chat_module
+        monkeypatch.setattr(chat_module, "_resolve_subdomain_to_id", lambda s: None)
+        with pytest.raises(ValueError, match="Could not resolve subdomain"):
+            Chat(publication_id="nonexistent", auth=mock_auth)
+
+    def test_get_threads(self, mock_auth, sample_threads_data):
+        """Test Chat.get_threads returns list of ChatThread objects."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = sample_threads_data
+        mock_auth.get.return_value = mock_response
+
+        chat = Chat(publication_id=4906951, auth=mock_auth)
+        threads = chat.get_threads()
+
+        assert len(threads) == len(sample_threads_data["threads"])
+        assert all(isinstance(t, ChatThread) for t in threads)
+        mock_auth.get.assert_called_once()
+
+    def test_get_threads_with_limit(self, mock_auth, sample_threads_data):
+        """Test Chat.get_threads respects limit parameter."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = sample_threads_data
+        mock_auth.get.return_value = mock_response
+
+        chat = Chat(publication_id=4906951, auth=mock_auth)
+        threads = chat.get_threads(limit=1)
+
+        assert len(threads) == 1
+
+    def test_get_threads_caching(self, mock_auth, sample_threads_data):
+        """Test Chat.get_threads uses cached data."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = sample_threads_data
+        mock_auth.get.return_value = mock_response
+
+        chat = Chat(publication_id=4906951, auth=mock_auth)
+
+        # First call - should fetch
+        chat.get_threads()
+        assert mock_auth.get.call_count == 1
+
+        # Second call - should use cache
+        chat.get_threads()
+        assert mock_auth.get.call_count == 1
+
+        # Force refresh - should fetch again
+        chat.get_threads(force_refresh=True)
+        assert mock_auth.get.call_count == 2
+
+    def test_get_threads_unauthenticated(self, mock_unauth):
+        """Test Chat.get_threads raises error when not authenticated."""
+        chat = Chat(publication_id=4906951, auth=mock_unauth)
+
+        with pytest.raises(ChatAuthenticationRequired):
+            chat.get_threads()
+
+    def test_get_threads_401_response(self, mock_auth):
+        """Test Chat.get_threads handles 401 response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_auth.get.return_value = mock_response
+
+        chat = Chat(publication_id=4906951, auth=mock_auth)
+
+        with pytest.raises(ChatAuthenticationRequired):
+            chat.get_threads()
+
+    def test_get_threads_402_response(self, mock_auth):
+        """Test Chat.get_threads handles 402 response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 402
+        mock_auth.get.return_value = mock_response
+
+        chat = Chat(publication_id=4906951, auth=mock_auth)
+
+        with pytest.raises(ChatPaymentRequired):
+            chat.get_threads()
+
+    def test_get_threads_403_response(self, mock_auth):
+        """Test Chat.get_threads handles 403 response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_auth.get.return_value = mock_response
+
+        chat = Chat(publication_id=4906951, auth=mock_auth)
+
+        with pytest.raises(ChatAccessDenied):
+            chat.get_threads()
+
+    def test_get_threads_404_response(self, mock_auth):
+        """Test Chat.get_threads handles 404 response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_auth.get.return_value = mock_response
+
+        chat = Chat(publication_id=4906951, auth=mock_auth)
+
+        with pytest.raises(ChatNotFound):
+            chat.get_threads()
+
+    def test_get_thread(self, mock_auth):
+        """Test Chat.get_thread returns a ChatThread object."""
+        chat = Chat(publication_id=4906951, auth=mock_auth)
+        thread = chat.get_thread("specific-thread-uuid")
+
+        assert isinstance(thread, ChatThread)
+        assert thread.thread_id == "specific-thread-uuid"
+        assert thread.publication_id == 4906951
+
+    def test_str_repr(self, mock_auth):
+        """Test Chat string representations."""
+        chat = Chat(publication_id=4906951, auth=mock_auth)
+        assert "4906951" in str(chat)
+        assert "4906951" in repr(chat)
+
+
+# ============================================================
+# Exception Tests
+# ============================================================
+
+
+class TestExceptions:
+    def test_chat_error_is_exception(self):
+        """Test ChatError is an Exception."""
+        assert issubclass(ChatError, Exception)
+
+    def test_chat_authentication_required_is_chat_error(self):
+        """Test ChatAuthenticationRequired inherits from ChatError."""
+        assert issubclass(ChatAuthenticationRequired, ChatError)
+
+    def test_chat_access_denied_is_chat_error(self):
+        """Test ChatAccessDenied inherits from ChatError."""
+        assert issubclass(ChatAccessDenied, ChatError)
+
+    def test_chat_payment_required_is_chat_access_denied(self):
+        """Test ChatPaymentRequired inherits from ChatAccessDenied."""
+        assert issubclass(ChatPaymentRequired, ChatAccessDenied)
+
+    def test_chat_not_found_is_chat_error(self):
+        """Test ChatNotFound inherits from ChatError."""
+        assert issubclass(ChatNotFound, ChatError)
+
+    def test_thread_not_found_is_chat_error(self):
+        """Test ThreadNotFound inherits from ChatError."""
+        assert issubclass(ThreadNotFound, ChatError)
+
+    def test_exception_message(self):
+        """Test exceptions can have custom messages."""
+        msg = "Custom error message"
+        error = ChatError(msg)
+        assert str(error) == msg
+
+
+# ============================================================
+# Integration-style Tests
+# ============================================================
+
+
+class TestIntegration:
+    def test_chat_to_thread_to_messages_flow(
+        self, mock_auth, sample_threads_data, sample_comments_data
+    ):
+        """Test the full flow from Chat -> Thread -> Messages."""
+        # Mock responses for different endpoints
+        def mock_get(url, **kwargs):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            if "/posts" in url and "comments" not in url:
+                mock_response.json.return_value = sample_threads_data
+            else:
+                mock_response.json.return_value = sample_comments_data
+            return mock_response
+
+        mock_auth.get.side_effect = mock_get
+
+        # Get chat
+        chat = Chat(publication_id=4906951, auth=mock_auth)
+
+        # Get threads
+        threads = chat.get_threads()
+        assert len(threads) > 0
+
+        # Get first thread
+        thread = threads[0]
+        assert isinstance(thread, ChatThread)
+
+        # Get messages from thread
+        messages = thread.get_messages()
+        assert len(messages) > 0
+        assert all(isinstance(m, ChatMessage) for m in messages)
+
+        # Check message properties
+        first_message = messages[0]
+        assert first_message.id is not None
+        assert first_message.body is not None
+        assert first_message.created_at is not None

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -322,6 +322,43 @@ class TestChatThread:
         thread.get_messages(force_refresh=True)
         assert mock_auth.get.call_count == 2
 
+    def test_get_messages_paginates_before(self, mock_auth):
+        """Test get_messages fetches all pages when moreBefore is True."""
+        older_page = {
+            "replies": [
+                {"comment": {"id": "old-msg-1", "body": "Older message", "created_at": "2026-01-20T10:00:00.000Z", "mediaAttachments": [], "reaction_count": 0}, "user": {"id": 1, "name": "User A", "handle": "usera"}},
+            ],
+            "moreBefore": False,
+            "moreAfter": False,
+        }
+        initial_page = {
+            "post": {"communityPost": {"id": "test-uuid", "body": "thread", "comment_count": 2}, "user": {"id": 1, "name": "User A"}},
+            "replies": [
+                {"comment": {"id": "new-msg-1", "body": "Newer message", "created_at": "2026-01-20T14:00:00.000Z", "mediaAttachments": [], "reaction_count": 0}, "user": {"id": 2, "name": "User B", "handle": "userb"}},
+            ],
+            "moreBefore": True,
+            "moreAfter": False,
+        }
+
+        def side_effect(url, params=None, timeout=None):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            if params and "before_id" in params:
+                mock_response.json.return_value = older_page
+            else:
+                mock_response.json.return_value = initial_page
+            return mock_response
+
+        mock_auth.get.side_effect = side_effect
+
+        thread = ChatThread(publication_id=4906951, thread_id="test-uuid", auth=mock_auth)
+        messages = thread.get_messages()
+
+        assert len(messages) == 2
+        assert messages[0].id == "old-msg-1"
+        assert messages[1].id == "new-msg-1"
+        assert mock_auth.get.call_count == 2
+
     def test_get_messages_unauthenticated(self, mock_unauth):
         """Test ChatThread.get_messages raises error when not authenticated."""
         thread = ChatThread(


### PR DESCRIPTION
## Summary

This is a revised version of #19, addressing all four points of the feedback from the other review.

- **Unrelated files removed** — `.gitattributes`, `.gitignore` additions (`.claude/`, `site/`, `.devcontainer/`), and `uv.lock` churn are not included
- **Dead fixture paths removed** — `test_chat.py` now uses only inline data; the `.claude/` file-loading code paths are gone
- **`limit` documented as client-side** — both `get_threads()` and `get_messages()` docstrings now clearly state the full page is always fetched and `limit` slices the result client-side
- **Subdomain resolution added** — `Chat("platformer", auth)` now works; non-numeric strings are resolved via the Substack search API, with a fallback to the publication's own `/api/v1/posts` endpoint for publications not indexed by search
- **`ChatPaymentRequired` added** — new exception (subclass of `ChatAccessDenied`) raised on 402 responses, covering both missing paid subscriptions and insufficient subscription tiers discovered during real-world testing

## Test plan

- [ ] `uv run pytest` — 172 tests passing, including 49 chat-specific tests
- [ ] `Chat("paulomacro", auth=auth).get_threads()` — subdomain resolution via posts fallback, returns threads and messages correctly (though this requires subscriber access, so swap out for something you subscribe to)
- [ ] `Chat(6474466, auth=auth).get_threads()` — raises `ChatPaymentRequired` for a publication where the user subscribes, but lacks chat access. Note - I'm a paid subscriber but not at a tier to get access to chat. Swap out the chat thread ID for one that matches a similar situation.